### PR TITLE
Remove file-loader fallback

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -52,7 +52,6 @@ function createSvgPlugin(pluginOptions = {}) {
               loader: require.resolve('url-loader'),
               options: {
                 limit: pluginOptions.limit || 8192,
-                fallback: require.resolve('next/dist/compiled/file-loader'),
                 publicPath: '/_next/',
                 /**
                  * In server-side compilation phase, `outputPath` defaults to


### PR DESCRIPTION
NextJs no longer ships a file loader in version 12; there is no next/dist/compiles/file-loader folder anymore. The Webpack configuration of this library for the url-loader respectively the fallback specified in the options is therefore no longer valid.

It is questionable when a fallback to the file-loader will be triggered.

- In NextJs 12, the fallback is both, not required in dev nor in production builds.
- In NextJs 11.1.2, same behavior, without a fallback option specified

If the fallback gets triggered in deployment is unknown; I have just linked the repo with my project locally.

This feature removes the fallback option entirely, both not to require resolving a file-loader nor specifying a dedicated file-loader in a stringified form.

fixes https://github.com/stefanprobst/next-svg/issues/2

@stefanprobst Can you please review the changes and, if fine, release a new version, thx!